### PR TITLE
automated build testing for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,16 @@ before_install:
   - sudo apt-get install libuv1/xenial -y -q
   - sudo apt-get install libuv1-dev/xenial -y -q
 
+# the stages are used to ensure that, in case of a failed build, the failure is detected early and the other long builds
+# are not run.
+# the setup time for a non opencv build is ca 3min in travis-ci
+# (because caer needs ubuntu 16.04 packages a lot of packages have to be installed)
+# the setup time for a OpenCV build is ca 28min in travis-ci
+# (because of lack of precompiled packages opencv has to be compiled before the build ca 25min)
+
 jobs:
   include:
-    - stage: plain-build
+    - stage: build plain
       before_script:
         # install latest libcaer release
         - wget -q --output-document=libcaer.zip https://api.github.com/repos/inilabs/libcaer/zipball
@@ -39,7 +46,7 @@ jobs:
         - make clean
         - make
         - ctest
-    - stage: module-build
+    - stage: build modules
       before_script:
         # install latest libcaer release
         - wget -q --output-document=libcaer.zip https://api.github.com/repos/inilabs/libcaer/zipball
@@ -53,7 +60,7 @@ jobs:
         - sudo make -s install
         - cd ..
       script:
-        # build with all default modules
+        # build with all default modules without opencv
         - cmake -DDVS128=1 -DEDVS=1 -DDAVIS=1 -DDYNAPSE=1 -DBAFILTER=1 -DFRAMEENHANCER=1 -DCAMERACALIBRATION=0
           -DPOSEESTIMATION=0 -DSTATISTICS=1 -DVISUALIZER=1 -DINPUT_FILE=1 -DOUTPUT_FILE=1 -DINPUT_NETWORK=1
           -DOUTPUT_NETWORK=1 -DROTATE=1 -DMEDIANTRACKER=1 -DRECTANGULARTRACKER=1 -DDYNAMICRECTANGULARTRACKER=1
@@ -61,7 +68,7 @@ jobs:
         - make clean
         - make
         - ctest
-    - stage: opencv-build # with opencv takes a long time!
+    - stage: build modules with OpenCV # with opencv takes a long time!
       before_script:
         # install opencv 3.1 +contrib
         - wget -q --output-document=opencv.zip https://github.com/opencv/opencv/archive/3.1.0.zip
@@ -88,7 +95,7 @@ jobs:
         - sudo make -s install
         - cd ..
       script:
-        # build with all default modules
+        # build with all default modules incl opencv
         - cmake -DDVS128=1 -DEDVS=1 -DDAVIS=1 -DDYNAPSE=1 -DBAFILTER=1 -DFRAMEENHANCER=1 -DCAMERACALIBRATION=1
           -DPOSEESTIMATION=1 -DSTATISTICS=1 -DVISUALIZER=1 -DINPUT_FILE=1 -DOUTPUT_FILE=1 -DINPUT_NETWORK=1
           -DOUTPUT_NETWORK=1 -DROTATE=1 -DMEDIANTRACKER=1 -DRECTANGULARTRACKER=1 -DDYNAMICRECTANGULARTRACKER=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: cpp
 
 sudo: required
-dist: trusty # newest ubuntu version in TRAVIS-CI
+dist: trusty # newest ubuntu version in TRAVIS-CI (will be partly upgraded)
 
 #install all required packages from ubuntu 16.04!
 before_install:
@@ -12,45 +12,86 @@ before_install:
   - sudo apt-get update -q
   #install requirements for libcaer and caer
   - sudo apt-get install unzip libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-system-dev
-    libmxml-dev libusb-1.0-0-dev liballegro5-dev libtcmalloc-minimal4 -y
+    libmxml-dev libusb-1.0-0-dev liballegro5-dev libtcmalloc-minimal4 -y -q
   # install libuv version 1.X which is not available in ubuntu 14.04
-  - sudo apt-get install g++/xenial -y
-  - sudo apt-get install libuv1/xenial -y
-  - sudo apt-get install libuv1-dev/xenial -y
+  - sudo apt-get install g++/xenial -y -q
+  - sudo apt-get install libuv1/xenial -y -q
+  - sudo apt-get install libuv1-dev/xenial -y -q
 
-before_script:
-  # install opencv 3.1 +contrib
-  - wget --output-document=opencv.zip https://github.com/opencv/opencv/archive/3.1.0.zip
-  - unzip opencv.zip
-  - cd opencv-3.1.0
-  - wget --output-document=opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/3.1.0.zip
-  - unzip opencv_contrib.zip
-  - mkdir build && cd build
-  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DWITH_IPP=ON -DINSTALL_CREATE_DISTRIB=ON
-    -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-3.1.0/modules/ -DBUILD_opencv_contrib_world=OFF
-    -DBUILD_opencv_xfeatures2d=OFF -DBUILD_opencv_matlab=OFF -DBUILD_opencv_text=OFF -DBUILD_opencv_xobjdetect=OFF -DBUILD_opencv_aruco=ON ../
-  - make
-  - sudo make install
-  - cd ../..
-  # install latest libcaer release
-  - wget --output-document=libcaer.zip https://api.github.com/repos/inilabs/libcaer/zipball
-  - unzip libcaer.zip
-  - rm libcaer.zip
-  - mv inilabs-l* libcaer
-  - cd libcaer
-  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_OPENCV=1 .
-  - make clean
-  - make
-  - sudo make install
-  - cd ..
-
-
-script:
-  # build with all default modules
-  - cmake -DDVS128=1 -DEDVS=1 -DDAVIS=1 -DDYNAPSE=1 -DBAFILTER=1 -DFRAMEENHANCER=1 -DCAMERACALIBRATION=1
-    -DPOSEESTIMATION=1 -DSTATISTICS=1 -DVISUALIZER=1 -DINPUT_FILE=1 -DOUTPUT_FILE=1 -DINPUT_NETWORK=1
-    -DOUTPUT_NETWORK=1 -DROTATE=1 -DMEDIANTRACKER=1 -DRECTANGULARTRACKER=1 -DDYNAMICRECTANGULARTRACKER=1
-    -DSPIKEFEATURES=1 -DMEANRATEFILTER=1 -DSYNAPSERECONFIG=1 -DFPGASPIKEGEN=1 -DPOISSONSPIKEGEN=1 .
-  - make clean
-  - make
-  - ctest
+jobs:
+  include:
+    - stage: plain-build
+      before_script:
+        # install latest libcaer release
+        - wget -q --output-document=libcaer.zip https://api.github.com/repos/inilabs/libcaer/zipball
+        - unzip -q libcaer.zip
+        - rm libcaer.zip
+        - mv inilabs-l* libcaer
+        - cd libcaer
+        - cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_OPENCV=0 .
+        - make -s clean
+        - make -s
+        - sudo make -s install
+        - cd ..
+      script:
+        # build with all default modules
+        - cmake .
+        - make clean
+        - make
+        - ctest
+    - stage: module-build
+      before_script:
+        # install latest libcaer release
+        - wget -q --output-document=libcaer.zip https://api.github.com/repos/inilabs/libcaer/zipball
+        - unzip -q libcaer.zip
+        - rm libcaer.zip
+        - mv inilabs-l* libcaer
+        - cd libcaer
+        - cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_OPENCV=0 .
+        - make -s clean
+        - make -s
+        - sudo make -s install
+        - cd ..
+      script:
+        # build with all default modules
+        - cmake -DDVS128=1 -DEDVS=1 -DDAVIS=1 -DDYNAPSE=1 -DBAFILTER=1 -DFRAMEENHANCER=1 -DCAMERACALIBRATION=0
+          -DPOSEESTIMATION=0 -DSTATISTICS=1 -DVISUALIZER=1 -DINPUT_FILE=1 -DOUTPUT_FILE=1 -DINPUT_NETWORK=1
+          -DOUTPUT_NETWORK=1 -DROTATE=1 -DMEDIANTRACKER=1 -DRECTANGULARTRACKER=1 -DDYNAMICRECTANGULARTRACKER=1
+          -DSPIKEFEATURES=1 -DMEANRATEFILTER=1 -DSYNAPSERECONFIG=1 -DFPGASPIKEGEN=1 -DPOISSONSPIKEGEN=1 .
+        - make clean
+        - make
+        - ctest
+    - stage: opencv-build # with opencv takes a long time!
+      before_script:
+        # install opencv 3.1 +contrib
+        - wget -q --output-document=opencv.zip https://github.com/opencv/opencv/archive/3.1.0.zip
+        - unzip -q opencv.zip
+        - cd opencv-3.1.0
+        - wget -q --output-document=opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/3.1.0.zip
+        - unzip -q opencv_contrib.zip
+        - mkdir build && cd build
+        - cmake -DCMAKE_INSTALL_PREFIX=/usr -DWITH_IPP=ON -DINSTALL_CREATE_DISTRIB=ON
+          -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-3.1.0/modules/ -DBUILD_opencv_contrib_world=OFF
+          -DBUILD_opencv_xfeatures2d=OFF -DBUILD_opencv_matlab=OFF -DBUILD_opencv_text=OFF -DBUILD_opencv_xobjdetect=OFF -DBUILD_opencv_aruco=ON ../
+        - make -s
+        - sudo make -s install
+        - cd ../..
+        # install latest libcaer release
+        - wget -q --output-document=libcaer.zip https://api.github.com/repos/inilabs/libcaer/zipball
+        - unzip -q libcaer.zip
+        - rm libcaer.zip
+        - mv inilabs-l* libcaer
+        - cd libcaer
+        - cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_OPENCV=1 .
+        - make -s clean
+        - make -s
+        - sudo make -s install
+        - cd ..
+      script:
+        # build with all default modules
+        - cmake -DDVS128=1 -DEDVS=1 -DDAVIS=1 -DDYNAPSE=1 -DBAFILTER=1 -DFRAMEENHANCER=1 -DCAMERACALIBRATION=1
+          -DPOSEESTIMATION=1 -DSTATISTICS=1 -DVISUALIZER=1 -DINPUT_FILE=1 -DOUTPUT_FILE=1 -DINPUT_NETWORK=1
+          -DOUTPUT_NETWORK=1 -DROTATE=1 -DMEDIANTRACKER=1 -DRECTANGULARTRACKER=1 -DDYNAMICRECTANGULARTRACKER=1
+          -DSPIKEFEATURES=1 -DMEANRATEFILTER=1 -DSYNAPSERECONFIG=1 -DFPGASPIKEGEN=1 -DPOISSONSPIKEGEN=1 .
+        - make clean
+        - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+## This CI script builds CAER with all default modules on UBUNTU 16.04.
+# all dependencies are the versions of the Ubuntu 16.04 LTS repo except opencv
+
+language: cpp
+
+sudo: required
+dist: trusty # newest ubuntu version in TRAVIS-CI
+
+#install all required packages from ubuntu 16.04!
+before_install:
+  - sudo add-apt-repository 'deb http://ch.archive.ubuntu.com/ubuntu xenial main universe' -y
+  - sudo apt-get update -q
+  #install requirements for libcaer and caer
+  - sudo apt-get install unzip libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-system-dev
+    libmxml-dev libusb-1.0-0-dev liballegro5-dev libtcmalloc-minimal4 -y
+  # install libuv version 1.X which is not available in ubuntu 14.04
+  - sudo apt-get install g++/xenial -y
+  - sudo apt-get install libuv1/xenial -y
+  - sudo apt-get install libuv1-dev/xenial -y
+
+before_script:
+  # install opencv 3.1 +contrib
+  - wget --output-document=opencv.zip https://github.com/opencv/opencv/archive/3.1.0.zip
+  - unzip opencv.zip
+  - cd opencv-3.1.0
+  - wget --output-document=opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/3.1.0.zip
+  - unzip opencv_contrib.zip
+  - mkdir build && cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DWITH_IPP=ON -DINSTALL_CREATE_DISTRIB=ON
+    -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-3.1.0/modules/ -DBUILD_opencv_contrib_world=OFF
+    -DBUILD_opencv_xfeatures2d=OFF -DBUILD_opencv_matlab=OFF -DBUILD_opencv_text=OFF -DBUILD_opencv_xobjdetect=OFF -DBUILD_opencv_aruco=ON ../
+  - make
+  - sudo make install
+  - cd ../..
+  # install latest libcaer release
+  - wget --output-document=libcaer.zip https://api.github.com/repos/inilabs/libcaer/zipball
+  - unzip libcaer.zip
+  - rm libcaer.zip
+  - mv inilabs-l* libcaer
+  - cd libcaer
+  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_OPENCV=1 .
+  - make clean
+  - make
+  - sudo make install
+  - cd ..
+
+
+script:
+  # build with all default modules
+  - cmake -DDVS128=1 -DEDVS=1 -DDAVIS=1 -DDYNAPSE=1 -DBAFILTER=1 -DFRAMEENHANCER=1 -DCAMERACALIBRATION=1
+    -DPOSEESTIMATION=1 -DSTATISTICS=1 -DVISUALIZER=1 -DINPUT_FILE=1 -DOUTPUT_FILE=1 -DINPUT_NETWORK=1
+    -DOUTPUT_NETWORK=1 -DROTATE=1 -DMEDIANTRACKER=1 -DRECTANGULARTRACKER=1 -DDYNAMICRECTANGULARTRACKER=1
+    -DSPIKEFEATURES=1 -DMEANRATEFILTER=1 -DSYNAPSERECONFIG=1 -DFPGASPIKEGEN=1 -DPOISSONSPIKEGEN=1 .
+  - make clean
+  - make
+  - ctest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 
 AER event-based framework, written in C, targeting embedded systems.
+[![Build Status](https://travis-ci.org/olerichter/caer.svg?branch=master)](https://travis-ci.org/olerichter/caer)
 
 # Dependencies:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # caer
 
 
-AER event-based framework, written in C, targeting embedded systems.
-[![Build Status](https://travis-ci.org/olerichter/caer.svg?branch=master)](https://travis-ci.org/olerichter/caer)
+AER event-based framework, written in C, targeting embedded systems.<br />
+[![Build Status](https://travis-ci.org/inilabs/caer.svg?branch=master)](https://travis-ci.org/inilabs/caer)
 
 # Dependencies:
 


### PR DESCRIPTION
I initially build a ci pipline for testing a caer module, and than generalised it so that it can be used for general caer development.

It builds on standard Ubuntu 16.04 LTS packages.

It uses stages because the opencv build takes very long (no prebuild packages for ubuntu 16.04 that include opencv_contrib)
the result can be seen here:
https://travis-ci.org/olerichter/caer