### PR TITLE
gen_spikes: fix doStim toggles in gui not being propagated through to…

### DIFF
--- a/modules/ini/dynapse_common.c
+++ b/modules/ini/dynapse_common.c
@@ -117,6 +117,7 @@ static void spikeConfigListener(sshsNode node, void *userData, enum sshs_node_at
 
 	if (event == SSHS_ATTRIBUTE_MODIFIED) {
 		if (changeType == SSHS_BOOL && caerStrEquals(changeKey, "doStim")) { // && caerStrEquals(changeKey, "doStimBias")
+			atomic_store(&state->genSpikeState.doStim, changeValue.boolean);
 		//atomic_load(&state->genSpikeState.doStim);
 			if (changeValue.boolean) {
 				//caerModuleLog(CAER_LOG_NOTICE, "spikeGen", "stimulation started.");


### PR DESCRIPTION
… gen_spikes state.

This was why the spike generator sleep fix did not work.