### PR TITLE
Mainloop: do not search modules in build dir by default, only in inst…

### DIFF
--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -41,12 +41,6 @@
 #define CM_SHARE_DIRECTORY "/usr/share/caer"
 #endif
 
-#ifdef CM_BUILD_DIR
-#define CM_BUILD_DIRECTORY INTERNAL_XSTR(CM_BUILD_DIR)
-#else
-#define CM_BUILD_DIRECTORY ""
-#endif
-
 #define MODULES_DIRECTORY "modules/"
 
 #include <libcaercpp/libcaer.hpp>
@@ -156,12 +150,10 @@ void caerMainloopRun(void) {
 	sshsNode modulesNode = sshsGetNode(sshsGetGlobal(), "/caer/modules/");
 
 	// Default search directories.
-	boost::filesystem::path modulesBuildDir(CM_BUILD_DIRECTORY);
-	modulesBuildDir.append(MODULES_DIRECTORY, boost::filesystem::path::codecvt());
 	boost::filesystem::path modulesDefaultDir(CM_SHARE_DIRECTORY);
 	modulesDefaultDir.append(MODULES_DIRECTORY, boost::filesystem::path::codecvt());
 
-	sshsNodeCreate(modulesNode, "modulesSearchPath", modulesBuildDir.string() + "|" + modulesDefaultDir.string(), 1,
+	sshsNodeCreate(modulesNode, "modulesSearchPath", modulesDefaultDir.string(), 1,
 		8 * PATH_MAX, SSHS_FLAGS_NORMAL, "Directories to search loadable modules in, separated by ':'.");
 
 	sshsNodeCreate(modulesNode, "modulesListOptions", "", 0, 10000, SSHS_FLAGS_READ_ONLY | SSHS_FLAGS_NO_EXPORT,


### PR DESCRIPTION
…all dir.

caer has to be installed to work properly.